### PR TITLE
Update to build on 7.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ The objective of this project is to build a new output to SQS to be used with th
 ## How to Build
 Before starting you must have Go Lang installed in your system, download it here https://golang.org/doc/install
 
+To avoid issues, use the same version as Elastic are using for Beats Development.
+You can check the version here: https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html
+
 Go to the beat folder you want to build
 ```bash
 cd beats/filebeat
@@ -14,6 +17,22 @@ If you have issues with dependencies, execute the go get command, example:
 ```bash
 go get github.com/elastic/beats/filebeat/cmd
 ```
+
+By default, go build will build using the head of https://github.com/elastic/beats.
+If you want to build on a specific commit/release:
+
+1. Clone the beats repo into your gopath
+```bash
+mkdir -p ${GOPATH}/src/github.com/elastic
+git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
+```
+2. Checkout the commit you want to build on
+3. Download the dependencies for the beats repo using:
+```bash
+cd ${GOPATH}/src/github.com/elastic/beats
+go mod vendor
+```
+
 
 ## How to Configure and install
 1. Download the beat from the elastic website, https://www.elastic.co/beats

--- a/beats/filebeat/main.go
+++ b/beats/filebeat/main.go
@@ -4,11 +4,13 @@ import (
 	"os"
 
 	"github.com/elastic/beats/filebeat/cmd"
+	inputs "github.com/elastic/beats/filebeat/input/default-inputs"
+
 	_ "github.com/renato0307/sqs_beats/outputs/sqs"
 )
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
+	if err := cmd.Filebeat(inputs.Init).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/outputs/sqs/client.go
+++ b/outputs/sqs/client.go
@@ -3,7 +3,8 @@ package sqs
 import (
 	"fmt"
 	"strconv"
-
+	"context"
+	
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -74,7 +75,7 @@ func (c *client) Connect() error {
 	return nil
 }
 
-func (c *client) Publish(batch publisher.Batch) error {
+func (c *client) Publish(_ context.Context, batch publisher.Batch) error {
 
 	log := logp.NewLogger(logSelector)
 

--- a/outputs/sqs/client_test.go
+++ b/outputs/sqs/client_test.go
@@ -20,7 +20,7 @@ func TestPublish(t *testing.T) {
 		svc:      svc,
 	}
 
-	err := c.Publish(batch)
+	err := c.Publish(nil, batch)
 
 	assert.Nil(t, err)
 }
@@ -39,7 +39,7 @@ func TestPublishWithError(t *testing.T) {
 		svc:      svc,
 	}
 
-	err := c.Publish(batch)
+	err := c.Publish(nil, batch)
 
 	assert.NotNil(t, err)
 }
@@ -58,7 +58,7 @@ func TestPublishWithFailedEvents(t *testing.T) {
 		svc:      svc,
 	}
 
-	err := c.Publish(batch)
+	err := c.Publish(nil , batch)
 
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
The following changes were made to allow the beats to be built using beats release 7.9.0 ( https://github.com/elastic/beats/releases/tag/v7.9.0 )

- Changed the Publish function signature to include a context object, as described in https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-7.8.html
- Updated the tests to reflect this change
- Changed the filebeat main function to be compatible with https://github.com/elastic/beats/pull/19686
- Updated the Readme with instructions for building using a specific beats commit